### PR TITLE
Fix typo in `description` parameter of `remove_role` slash command decorator

### DIFF
--- a/discord_bot/cogs/admin_palette/role_manager.py
+++ b/discord_bot/cogs/admin_palette/role_manager.py
@@ -25,7 +25,7 @@ class RoleManager(commands.Cog):
                 f"{member.name}님에게 {role.name} 역할을 추가했습니다."
             )
 
-    @slash_command(discription="remove a role from a user", guild_id=GUILD_ID)
+    @slash_command(description="remove a role from a user", guild_id=GUILD_ID)
     @commands.has_permissions(administrator=True)
     async def remove_role(
         self, ctx, member: discord.Member, role: discord.Role


### PR DESCRIPTION
## 이슈 
#23 : 슬래시 명령어 데코레이터에서 `description` 파라미터에 오타 발생

## 수정 사항
`remove_role` 명령어의 데코레이터에서 `description` 오타를 수정했습니다.

### 수정된 코드
`discord_bot/role_manager.py`:
https://github.com/SUSC-KR/Discord-Bot/blob/d9b55795a115625a317ef63229dafbc9c6f67c74/discord_bot/cogs/admin_palette/role_manager.py#L28

```python
@slash_command(description="remove a role from a user", guild_id=GUILD_ID)