### PR TITLE
fix: 스터디 생성 시 애플리케이션이 응답하지 않는 문제 수정

### DIFF
--- a/discord_bot/cogs/admin_palette/study_manager.py
+++ b/discord_bot/cogs/admin_palette/study_manager.py
@@ -2,7 +2,6 @@ import discord
 from discord.commands import slash_command
 from discord.ext import commands
 
-
 class StudyManager(commands.Cog):
     def __init__(self, bot):
         self.bot = bot
@@ -11,12 +10,15 @@ class StudyManager(commands.Cog):
     @commands.has_permissions(administrator=True)
     async def create_study(
         self,
-        ctx,
+        ctx: discord.ApplicationContext,
         study_name: str,
         year: str,
         season: str,
         category_name: str = None,
     ):
+        # 처리가 3초 이상 걸릴 수 있기 때문에 `defer`를 사용하여 timeout을 방지합니다.
+        await ctx.defer()
+
         guild = ctx.guild
         study_name = study_name.upper()
         season = season.upper()
@@ -26,16 +28,25 @@ class StudyManager(commands.Cog):
         role_name = f"{year_short}-{season}-{study_name}"
 
         if await self.role_exists(guild, role_name):
-            return await ctx.send(f"'{role_name}' 역할이 이미 존재합니다.")
+            return await ctx.edit(f"'{role_name}' 역할이 이미 존재합니다.")
 
         category = await self.get_or_create_category(guild, category_name, role_name)
         await self.create_study_channels(guild, category, study_name, role_name)
 
-        await ctx.send(f"'{role_name}' 스터디 역할과 채널이 생성되었습니다.")
+        await ctx.interaction.edit_original_response(content=f"'{role_name}' 스터디 역할과 채널이 생성되었습니다.")
 
     @slash_command(description="Delete study room and migrate role members")
     @commands.has_permissions(administrator=True)
-    async def delete_study(self, ctx, year: str, study_name: str, season: str, category_name: str):
+    async def delete_study(
+        self,
+        ctx: discord.ApplicationContext,
+        year: str,
+        study_name: str,
+        season: str,
+        category_name: str
+    ):
+        await ctx.defer()
+
         guild = ctx.guild
         season = season.upper()
         year_short, year_long = year[-2:], year[-4:]
@@ -45,15 +56,14 @@ class StudyManager(commands.Cog):
 
         category = discord.utils.get(guild.categories, name=category_name)
         if not category:
-            return await ctx.send(f"'{category_name}' 카테고리가 존재하지 않습니다.")
+            return await ctx.edit(content=f"'{category_name}' 카테고리가 존재하지 않습니다.")
 
         await self.delete_study_channels_with_study_name(category, study_name)
         season_role = await self.get_or_create_role(guild, season_role_name)
         await self.migrate_members_from_role(guild, role_name, season_role)
 
-        await ctx.send(
-            f"'{category_name}' 카테고리와 관련된 스터디 룸과 역할이 삭제되고, 멤버가 '{season_role_name}' 역할로 이동되었습니다."
-        )
+        success_message = f"'{category_name}' 카테고리와 관련된 스터디 룸과 역할이 삭제되고, 멤버가 '{season_role_name}' 역할로 이동되었습니다."
+        await ctx.edit(content=success_message)
 
     async def role_exists(self, guild, role_name):
         return discord.utils.get(guild.roles, name=role_name) is not None

--- a/discord_bot/cogs/admin_palette/study_manager.py
+++ b/discord_bot/cogs/admin_palette/study_manager.py
@@ -2,6 +2,7 @@ import discord
 from discord.commands import slash_command
 from discord.ext import commands
 
+
 class StudyManager(commands.Cog):
     def __init__(self, bot):
         self.bot = bot


### PR DESCRIPTION
### Summary

스터디 생성 시 애플리케이션이 응답하지 않는 문제를 수정합니다.
Fixes #36 

### Detail

`ctx.send`는 단순히 메시지를 전송하는 역할만 하고, 요청을 마무리하는 역할을 하진 않습니다.
디스코드 봇의 경우 요청 처리가 완료된 후에는 다시 디스코드 서버로 콜백을 날려주어야 봇이 응답을 완료하였다고 판단합니다.

만약 콜백을 보내지 않은 경우 디스코드 서버는 봇이 응답을 하지 않았거나 서버가 죽었다고 판단하여, `애플리케이션이 응답하지 않았어요` 에러를 내보내게 되는 것입니다.

따라서, 일반적인 경우 요청을 마무리하기 위해 `ctx.responsd`를 호출하여 응답을 보내야 합니다.

추가적으로, 디스코드 서버는 콜백의 timeout을 3초로 지정하여, 3초 내에 콜백을 보내지 않는 경우 애플리케이션이 응답하지 않았다고 봅니다.

> Interaction tokens are valid for 15 minutes and can be used to send followup messages but you must send an initial response within 3 seconds of receiving the event. If the 3 second deadline is exceeded, the token will be invalidated.
> https://discord.com/developers/docs/interactions/receiving-and-responding#interaction-callback

하지만 스터디 생성 명령어는 HTTP 요청을 여러 번 보내야 하기 때문에 3초 내에 끝내지 못할 때도 있는데, 이 경우 `ctx.defer()`를 호출하여 응답 처리 시간을 3초에서 15분으로 늘릴 수 있습니다.

<img width="320" alt="image" src="https://github.com/user-attachments/assets/98bec548-b0e1-499f-82f6-d8a3c8bf5f22" />

이 경우 유저에게 위와 같이 "생각 중이다"라는 응답이 나간 상태이므로, 이후 따라오는 응답은 `edit()`을 호출하여야 합니다. 만약 `edit()`을 호출하지 않는 경우 15분 후 응답하지 않는다는 에러가 발생합니다.